### PR TITLE
Update comments migration

### DIFF
--- a/migrations/20170510121203_add_replies_to_comments.js
+++ b/migrations/20170510121203_add_replies_to_comments.js
@@ -1,11 +1,13 @@
-exports.up = knex => knex.schema.table('comments', table => {
+exports.up = function(knex, Promise) {
+  return knex.schema.table('comments', function (table) {
     table.integer('parent_id').references('comments.id')
     table.string('edited')
     table.string('deleted')
   })
 }
 
-exports.down = knex => knex.schema.table('comments', table => {
+exports.down = function(knex, Promise) {
+  return knex.schema.table('comments', function (table) {
       table.dropColumn('parent_id')
       table.dropColumn('edited')
       table.dropColumn('deleted')

--- a/migrations/20170510121203_add_replies_to_comments.js
+++ b/migrations/20170510121203_add_replies_to_comments.js
@@ -1,0 +1,13 @@
+exports.up = knex => knex.schema.table('comments', table => {
+    table.integer('parent_id').references('comments.id')
+    table.string('edited')
+    table.string('deleted')
+  })
+}
+
+exports.down = knex => knex.schema.table('comments', table => {
+      table.dropColumn('parent_id')
+      table.dropColumn('edited')
+      table.dropColumn('deleted')
+  })
+}


### PR DESCRIPTION
Added the following three columns to the comments table via a new migration: 

- parent_id (integer - references the id of the parent comment, to track which comments are replies);
- edited (string - the date at which the comment was last edited);
- deleted (string - the date at which the comment was deleted).